### PR TITLE
outputの末尾の改行を無視

### DIFF
--- a/make_test.py
+++ b/make_test.py
@@ -52,9 +52,8 @@ for problem in PROBLEMS:
 
         with open(out_path, 'r') as f:
             raw = f.read()
-            # 末尾に改行があれば1つだけ取り除く
-            if raw.endswith('\n'):
-                raw = raw[:-1]
+            # 末尾のすべての空白文字（改行含む）を削除
+            raw = raw.rstrip()
             expected = escape_cpp_string(raw)
 
         exe_path = os.path.abspath(os.path.join(ROOT_DIR, 'build', problem, problem))


### PR DESCRIPTION
## 背景

- AtCoderでコピーボタンを押して出力を持ってくると最後に改行がある
- それ以外も，ダウンロードするタイプの出力例はたいてい改行が最後にある
- 改行があると，コード側でendlしててもテストが落ちる

![image](https://github.com/user-attachments/assets/0257d695-da44-46b3-838b-7f7400c698a1)

## 内容

- `make_test.py` で末尾の改行があるなら1個消して正規化