### PR TITLE
ヘルプコマンドを追加

### DIFF
--- a/.init
+++ b/.init
@@ -142,27 +142,48 @@ cprun() {
 	done
 }
 
+cphelp() {
+	cat << EOF
+競技プログラミング用コマンド:
+  cpc build|b [problems...]  - ビルド
+  cpc test|t [problems...]   - テスト実行 (結果をクリップボードにコピー)
+  cpc run|r [problems...]    - 実行
+  cpc make|m [problems...]   - テスト生成
+  cpc configure|c            - 初期設定
+
+有効な問題: ${problems[*]}
+例: cpc test a b c
+EOF
+}
+
 cpc() {
 	case "$1" in
 		"build"|"b")
-		shift
-		cpbuild "$@"
-		;;
+			shift
+			cpbuild "$@"
+			;;
 		"test"|"t")
-		shift
-		cptest "$@"
-		;;
+			shift
+			cptest "$@"
+			;;
 		"configure"|"c")
-		cpconfigure
-		;;
+			cpconfigure
+			;;
 		"make"|"m")
-		shift
-		cpmake "$@"
-		;;
+			shift
+			cpmake "$@"
+			;;
 		"run"|"r")
-		shift
-		cprun "$@"
-		;;
+			shift
+			cprun "$@"
+			;;
+		"help"|"h"|"")
+			cphelp
+			;;
+		*)
+			echo "Unknown command: $1" >&2
+			cphelp
+			;;
 	esac
 }
 


### PR DESCRIPTION
## 背景

必要な時にオプションがどれがどれだかわからなくなる自信があるので、`cpc` のヘルプコマンドを追加

## 内容

以下のどれかをトリガとして簡単なコマンドヘルプを表示

- `cpchelp`
- `cpc h`
- `cpc` （引数なし）

## 動作例

```
❯ cpc
競技プログラミング用コマンド:
  cpc build|b [problems...]  - ビルド
  cpc test|t [problems...]   - テスト実行 (結果をクリップボードにコピー)
  cpc run|r [problems...]    - 実行
  cpc make|m [problems...]   - テスト生成
  cpc configure|c            - 初期設定

有効な問題: a b c d e f g h i
例: cpc test a b c
```